### PR TITLE
Add itisandria.it domain

### DIFF
--- a/lib/domains/it/itisandria.txt
+++ b/lib/domains/it/itisandria.txt
@@ -1,4 +1,3 @@
-
 ITIS "Sen. O. Jannuzzi" Andria
 
 ITIS Jannuzzi

--- a/lib/domains/it/itisandria.txt
+++ b/lib/domains/it/itisandria.txt
@@ -1,0 +1,4 @@
+
+ITIS "Sen. O. Jannuzzi" Andria
+
+ITIS Jannuzzi


### PR DESCRIPTION
Official website: http://itisandria.edu.it/

However, the website http://itisandria.it/ is still a valid website.

IT course: http://itisandria.edu.it/index.php/la-scuola/carta-d-identita-della-scuola/l-informatica

![proof](https://user-images.githubusercontent.com/56970875/116779189-50900780-aa64-11eb-8a23-fdeb3ecefec9.jpg)
